### PR TITLE
Solve TypeMap constraint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -151,12 +151,14 @@ Model generation will still continue, no worries.
     return source;
 }
 
-function generateIndex(collections: CollectionsOverview): string {
+function generateIndex(collections: CollectionsOverview, indexType: 'interface' | 'type'): string {
     let source = ``;
-    console.log({collections});
-    source += '\nexport type Collections = {\n';
+    source += `\nexport ${indexType} Collections${indexType === 'type' ? 'SDK =' : ''} {\n`;
     Object.values(collections).forEach((collection: Collection) => {
-        source += `  ${collection.collection}: ${className(collection)}${collection.singleton ? '' : '[]'};\n`
+        const closingChar = indexType === 'type' ? ',' : ''
+        const collectionDefinition = `${collection.collection}: ${className(collection)}`
+        const singleton = !collection.singleton && indexType === 'interface' ? '[]' : ''
+        source += `  ${collectionDefinition}${singleton}${closingChar}\n`
     });
     source += '}\n';
     return source;
@@ -189,7 +191,8 @@ export default defineHook(async ({init}, {services, getSchema, database, logger}
                 }
 
                 // Generate the index
-                source += generateIndex(collections);
+                source += generateIndex(collections, 'interface');
+                source += generateIndex(collections, 'type');
                 await writeFile(file, source);
                 process.exit(0);
             });


### PR DESCRIPTION
The most recent version presented two issues when utilized alongside the Directus SDK:

- The presence of a semicolon (;) in the index export triggered the "Type 'Collections' does not satisfy the constraint 'TypeMap'" error.
- The array signature, which was recently introduced, caused problems when the model was not a singleton.
To address these concerns, I propose the following approach:

We establish two distinct index exports. The first encompasses an interface with the appended array. The second entails a type export that meets the criteria of the TypeMap constraint, using commas instead of semicolons.
I have tested this pull request in one of my ongoing projects.